### PR TITLE
Don't export es6 in glue code

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,12 +74,12 @@ module.exports = function(source) {
       return {
         // Returns a promise that resolves when the wasm runtime is initialized and ready for use
         initialize: function(userDefinedModule) {
-          return new Promise((resolve, reject) => {
+          return new Promise(function(resolve, reject) {
             if (!userDefinedModule) {
               userDefinedModule = {}
             }
             var Module = Object.assign({}, userDefinedModule, existingModule);
-            Module['onRuntimeInitialized'] = () => resolve(Module);
+            Module['onRuntimeInitialized'] = function() { resolve(Module) };
             \n${out}\n
           });
         }


### PR DESCRIPTION
Hey,

This loader is super awesome, and has made integrating wasm with our code much more straightforward.  Trying to build with `webpack -p` for production, the arrow functions in `const glue` are tripping up UglifyJS - this PR replaces them with es5 uglify-friendly functions.

Thanks for your great work!